### PR TITLE
chore: including Type Definition for Typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,49 @@
+// Type definitions for handlebars-helpers 0.5
+// Project: http://assemble.io/helpers/, https://github.com/helpers/handlebars-helpers
+// Definitions by: Toilal <https://github.com/Toilal>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+
+import * as Handlebars from 'handlebars';
+
+declare function helpers(groups?: helpers.Options | string | string[], options?: helpers.Options): { [name: string]: Handlebars.HelperDelegate };
+
+interface Utils {
+    /**
+     * Returns true if the given value contains the given
+     * `object`, optionally passing a starting index.
+     */
+    contains<T>(val: T[], obj: T, start: number): boolean;
+
+    /**
+     * Remove leading and trailing whitespace and non-word
+     * characters from the given string.
+     */
+    chop(str: string): string;
+
+    /**
+     * Change casing on the given `string`, optionally
+     * passing a delimiter to use between words in the
+     * returned string.
+     *
+     * ```handlebars
+     * utils.changecase('fooBarBaz');
+     * //=> 'foo bar baz'
+     *
+     * utils.changecase('fooBarBaz' '-');
+     * //=> 'foo-bar-baz'
+     * ```
+     */
+    changecase(str: string, fn: (str: string) => string): string;
+}
+
+declare namespace helpers {
+    interface Options {
+        handlebars?: typeof Handlebars | undefined;
+        hbs?: typeof Handlebars | undefined;
+    }
+
+    const utils: Utils;
+}
+
+export = helpers;

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "index.d.ts"
   ],
   "main": "index.js",
+  "types": "index.d.ts",
   "engines": {
     "node": ">=0.12.0"
   },

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "templates": "^0.13.7",
     "through2": "^2.0.3",
     "verb-generate-readme": "^0.8.0",
-    "vinyl": "^2.1.0"
+    "vinyl": "^2.2.1"
   },
   "keywords": [
     "array",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
   "license": "MIT",
   "files": [
     "index.js",
-    "lib"
+    "lib",
+    "index.d.ts"
   ],
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Currently when using typescript on this fork it errors out because it cannot use @types/handlebars-helpers. This is resolved by moving it to the main package. 

Also, upgrading vinyl to latest version. 