### PR TITLE
Package maintenance updates: through2, templates, and template-helpers to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "mocha": "^10.0.0",
     "template-helpers": "^0.6.7",
     "templates": "^0.13.7",
-    "through2": "^2.0.3",
+    "through2": "^4.0.2",
     "verb-generate-readme": "^0.8.0",
     "vinyl": "^2.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "markdown-link": "^0.1.1",
     "mocha": "^10.0.0",
     "template-helpers": "^0.6.7",
-    "templates": "^0.13.7",
+    "templates": "^1.2.9",
     "through2": "^4.0.2",
     "verb-generate-readme": "^0.8.0",
     "vinyl": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "js-yaml": "^3.10.0",
     "markdown-link": "^0.1.1",
     "mocha": "^10.0.0",
-    "template-helpers": "^0.6.7",
+    "template-helpers": "^1.0.1",
     "templates": "^1.2.9",
     "through2": "^4.0.2",
     "verb-generate-readme": "^0.8.0",


### PR DESCRIPTION
Upgrading the following packages to latest:
- through2 to 4.0.2
- templates to 1.2.9
- template-helpers to 1.0.1

All tests have passed. 