### PR TITLE
upgrading mocha to 10.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "is-valid-app": "^0.3.0",
     "js-yaml": "^4.1.0",
     "markdown-link": "^0.1.1",
-    "mocha": "^10.1.0",
+    "mocha": "^10.2.0",
     "template-helpers": "^1.0.1",
     "templates": "^1.2.9",
     "through2": "^4.0.2",


### PR DESCRIPTION
@jonathas no rush on this one as the only package out of date is `mocha` and a minor update. 