### PR TITLE
chore: upgrading @commitlint to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,8 +39,8 @@
         "year": "^0.2.1"
       },
       "devDependencies": {
-        "@commitlint/cli": "^17.4.1",
-        "@commitlint/config-conventional": "^17.4.0",
+        "@commitlint/cli": "^17.4.2",
+        "@commitlint/config-conventional": "^17.4.2",
         "auto-changelog": "^2.4.0",
         "engine-handlebars": "^1.1.0",
         "fs-exists-sync": "^0.1.0",
@@ -105,15 +105,15 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.4.1.tgz",
-      "integrity": "sha512-W8OJwz+izY+fVwyUt1HveCDmABMZNRVZHSVPw/Bh9Y62tp11SmmQaycgbsYLMiMy7JGn4mAJqEGlSHS9Uti9ZQ==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.4.2.tgz",
+      "integrity": "sha512-0rPGJ2O1owhpxMIXL9YJ2CgPkdrFLKZElIZHXDN8L8+qWK1DGH7Q7IelBT1pchXTYTuDlqkOTdh//aTvT3bSUA==",
       "dev": true,
       "dependencies": {
         "@commitlint/format": "^17.4.0",
-        "@commitlint/lint": "^17.4.0",
-        "@commitlint/load": "^17.4.1",
-        "@commitlint/read": "^17.4.0",
+        "@commitlint/lint": "^17.4.2",
+        "@commitlint/load": "^17.4.2",
+        "@commitlint/read": "^17.4.2",
         "@commitlint/types": "^17.4.0",
         "execa": "^5.0.0",
         "lodash.isfunction": "^3.0.9",
@@ -282,9 +282,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.4.0.tgz",
-      "integrity": "sha512-G4XBf45J4ZMspO4NwBFzY3g/1Kb+B42BcIxeikF8wucQxcyxcmhRdjeQpRpS1XEcBq5pdtEEQFipuB9IuiNFhw==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.4.2.tgz",
+      "integrity": "sha512-JVo1moSj5eDMoql159q8zKCU8lkOhQ+b23Vl3LVVrS6PXDLQIELnJ34ChQmFVbBdSSRNAbbXnRDhosFU+wnuHw==",
       "dev": true,
       "dependencies": {
         "conventional-changelog-conventionalcommits": "^5.0.0"
@@ -416,9 +416,9 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.4.0.tgz",
-      "integrity": "sha512-mkRuBlPUaBimvSvJyIHEHEW1/jP1SqEI7NOoaO9/eyJkMbsaiv5b1QgDYL4ZXlHdS64RMV7Y21MVVzuIceImDA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.4.2.tgz",
+      "integrity": "sha512-1b2Y2qJ6n7bHG9K6h8S4lBGUl6kc7mMhJN9gy1SQfUZqe92ToDjUTtgNWb6LbzR1X8Cq4SEus4VU8Z/riEa94Q==",
       "dev": true,
       "dependencies": {
         "@commitlint/types": "^17.4.0",
@@ -444,14 +444,14 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.4.0.tgz",
-      "integrity": "sha512-HG2YT4TUbQKs9v8QvpQjJ6OK+fhflsDB8M+D5tLrY79hbQOWA9mDKdRkABsW/AAhpNI9+zeGUWF3jj245jSHKw==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.4.2.tgz",
+      "integrity": "sha512-HcymabrdBhsDMNzIv146+ZPNBPBK5gMNsVH+el2lCagnYgCi/4ixrHooeVyS64Fgce2K26+MC7OQ4vVH8wQWVw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/is-ignored": "^17.4.0",
-        "@commitlint/parse": "^17.4.0",
-        "@commitlint/rules": "^17.4.0",
+        "@commitlint/is-ignored": "^17.4.2",
+        "@commitlint/parse": "^17.4.2",
+        "@commitlint/rules": "^17.4.2",
         "@commitlint/types": "^17.4.0"
       },
       "engines": {
@@ -459,9 +459,9 @@
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.4.1.tgz",
-      "integrity": "sha512-6A7/LhIaQpL4ieciIDcVvK2d5z/UI1GBrtDaHm6sQSCL0265clB2/F7XKQNTJHXv9yG4LByT2r+QCpM4GugIfw==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.4.2.tgz",
+      "integrity": "sha512-Si++F85rJ9t4hw6JcOw1i2h0fdpdFQt0YKwjuK4bk9KhFjyFkRxvR3SB2dPaMs+EwWlDrDBGL+ygip1QD6gmPw==",
       "dev": true,
       "dependencies": {
         "@commitlint/config-validator": "^17.4.0",
@@ -554,18 +554,18 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.4.0.tgz",
-      "integrity": "sha512-USGJDU9PPxcgQjKXCzvPUal65KAhxWq3hp+MrU1pNCN2itWM654CLIoY2LMIQ7rScTli9B5dTLH3vXhzbItmzA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.4.2.tgz",
+      "integrity": "sha512-3XMNbzB+3bhKA1hSAWPCQA3lNxR4zaeQAQcHj0Hx5sVdO6ryXtgUBGGv+1ZCLMgAPRixuc6en+iNAzZ4NzAa8Q==",
       "dev": true,
       "engines": {
         "node": ">=v14"
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.4.0.tgz",
-      "integrity": "sha512-x8opKc5p+Hgs+CrMbq3VAnW2L2foPAX6arW8u9c8nTzksldGgFsENT+XVyPmpSMLlVBswZ1tndcz1xyKiY9TJA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.4.2.tgz",
+      "integrity": "sha512-DK4EwqhxfXpyCA+UH8TBRIAXAfmmX4q9QRBz/2h9F9sI91yt6mltTrL6TKURMcjUVmgaB80wgS9QybNIyVBIJA==",
       "dev": true,
       "dependencies": {
         "@commitlint/types": "^17.4.0",
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-17.4.0.tgz",
-      "integrity": "sha512-pGDeZpbkyvhxK8ZoCDUacPPRpauKPWF3n2XpDBEnuGreqUF2clq2PVJpwMMaNN5cHW8iFKCbcoOjXhD01sln0A==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-17.4.2.tgz",
+      "integrity": "sha512-hasYOdbhEg+W4hi0InmXHxtD/1favB4WdwyFxs1eOy/DvMw6+2IZBmATgGOlqhahsypk4kChhxjAFJAZ2F+JBg==",
       "dev": true,
       "dependencies": {
         "@commitlint/top-level": "^17.4.0",
@@ -610,13 +610,13 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.4.0.tgz",
-      "integrity": "sha512-lz3i1jet2NNjTWpAMwjjQjMZCPWBIHK1Kkja9o09UmUtMjRdALTb8uMLe8gCyeq3DiiZ5lLYOhbsoPK56xGQKA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.4.2.tgz",
+      "integrity": "sha512-OGrPsMb9Fx3/bZ64/EzJehY9YDSGWzp81Pj+zJiY+r/NSgJI3nUYdlS37jykNIugzazdEXfMtQ10kmA+Kx2pZQ==",
       "dev": true,
       "dependencies": {
         "@commitlint/ensure": "^17.4.0",
-        "@commitlint/message": "^17.4.0",
+        "@commitlint/message": "^17.4.2",
         "@commitlint/to-lines": "^17.4.0",
         "@commitlint/types": "^17.4.0",
         "execa": "^5.0.0"
@@ -19456,9 +19456,9 @@
       }
     },
     "node_modules/ts-node/node_modules/acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -21594,15 +21594,15 @@
       }
     },
     "@commitlint/cli": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.4.1.tgz",
-      "integrity": "sha512-W8OJwz+izY+fVwyUt1HveCDmABMZNRVZHSVPw/Bh9Y62tp11SmmQaycgbsYLMiMy7JGn4mAJqEGlSHS9Uti9ZQ==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.4.2.tgz",
+      "integrity": "sha512-0rPGJ2O1owhpxMIXL9YJ2CgPkdrFLKZElIZHXDN8L8+qWK1DGH7Q7IelBT1pchXTYTuDlqkOTdh//aTvT3bSUA==",
       "dev": true,
       "requires": {
         "@commitlint/format": "^17.4.0",
-        "@commitlint/lint": "^17.4.0",
-        "@commitlint/load": "^17.4.1",
-        "@commitlint/read": "^17.4.0",
+        "@commitlint/lint": "^17.4.2",
+        "@commitlint/load": "^17.4.2",
+        "@commitlint/read": "^17.4.2",
         "@commitlint/types": "^17.4.0",
         "execa": "^5.0.0",
         "lodash.isfunction": "^3.0.9",
@@ -21725,9 +21725,9 @@
       }
     },
     "@commitlint/config-conventional": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.4.0.tgz",
-      "integrity": "sha512-G4XBf45J4ZMspO4NwBFzY3g/1Kb+B42BcIxeikF8wucQxcyxcmhRdjeQpRpS1XEcBq5pdtEEQFipuB9IuiNFhw==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.4.2.tgz",
+      "integrity": "sha512-JVo1moSj5eDMoql159q8zKCU8lkOhQ+b23Vl3LVVrS6PXDLQIELnJ34ChQmFVbBdSSRNAbbXnRDhosFU+wnuHw==",
       "dev": true,
       "requires": {
         "conventional-changelog-conventionalcommits": "^5.0.0"
@@ -21825,9 +21825,9 @@
       }
     },
     "@commitlint/is-ignored": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.4.0.tgz",
-      "integrity": "sha512-mkRuBlPUaBimvSvJyIHEHEW1/jP1SqEI7NOoaO9/eyJkMbsaiv5b1QgDYL4ZXlHdS64RMV7Y21MVVzuIceImDA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.4.2.tgz",
+      "integrity": "sha512-1b2Y2qJ6n7bHG9K6h8S4lBGUl6kc7mMhJN9gy1SQfUZqe92ToDjUTtgNWb6LbzR1X8Cq4SEus4VU8Z/riEa94Q==",
       "dev": true,
       "requires": {
         "@commitlint/types": "^17.4.0",
@@ -21846,21 +21846,21 @@
       }
     },
     "@commitlint/lint": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.4.0.tgz",
-      "integrity": "sha512-HG2YT4TUbQKs9v8QvpQjJ6OK+fhflsDB8M+D5tLrY79hbQOWA9mDKdRkABsW/AAhpNI9+zeGUWF3jj245jSHKw==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.4.2.tgz",
+      "integrity": "sha512-HcymabrdBhsDMNzIv146+ZPNBPBK5gMNsVH+el2lCagnYgCi/4ixrHooeVyS64Fgce2K26+MC7OQ4vVH8wQWVw==",
       "dev": true,
       "requires": {
-        "@commitlint/is-ignored": "^17.4.0",
-        "@commitlint/parse": "^17.4.0",
-        "@commitlint/rules": "^17.4.0",
+        "@commitlint/is-ignored": "^17.4.2",
+        "@commitlint/parse": "^17.4.2",
+        "@commitlint/rules": "^17.4.2",
         "@commitlint/types": "^17.4.0"
       }
     },
     "@commitlint/load": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.4.1.tgz",
-      "integrity": "sha512-6A7/LhIaQpL4ieciIDcVvK2d5z/UI1GBrtDaHm6sQSCL0265clB2/F7XKQNTJHXv9yG4LByT2r+QCpM4GugIfw==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.4.2.tgz",
+      "integrity": "sha512-Si++F85rJ9t4hw6JcOw1i2h0fdpdFQt0YKwjuK4bk9KhFjyFkRxvR3SB2dPaMs+EwWlDrDBGL+ygip1QD6gmPw==",
       "dev": true,
       "requires": {
         "@commitlint/config-validator": "^17.4.0",
@@ -21931,15 +21931,15 @@
       }
     },
     "@commitlint/message": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.4.0.tgz",
-      "integrity": "sha512-USGJDU9PPxcgQjKXCzvPUal65KAhxWq3hp+MrU1pNCN2itWM654CLIoY2LMIQ7rScTli9B5dTLH3vXhzbItmzA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.4.2.tgz",
+      "integrity": "sha512-3XMNbzB+3bhKA1hSAWPCQA3lNxR4zaeQAQcHj0Hx5sVdO6ryXtgUBGGv+1ZCLMgAPRixuc6en+iNAzZ4NzAa8Q==",
       "dev": true
     },
     "@commitlint/parse": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.4.0.tgz",
-      "integrity": "sha512-x8opKc5p+Hgs+CrMbq3VAnW2L2foPAX6arW8u9c8nTzksldGgFsENT+XVyPmpSMLlVBswZ1tndcz1xyKiY9TJA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.4.2.tgz",
+      "integrity": "sha512-DK4EwqhxfXpyCA+UH8TBRIAXAfmmX4q9QRBz/2h9F9sI91yt6mltTrL6TKURMcjUVmgaB80wgS9QybNIyVBIJA==",
       "dev": true,
       "requires": {
         "@commitlint/types": "^17.4.0",
@@ -21948,9 +21948,9 @@
       }
     },
     "@commitlint/read": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-17.4.0.tgz",
-      "integrity": "sha512-pGDeZpbkyvhxK8ZoCDUacPPRpauKPWF3n2XpDBEnuGreqUF2clq2PVJpwMMaNN5cHW8iFKCbcoOjXhD01sln0A==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-17.4.2.tgz",
+      "integrity": "sha512-hasYOdbhEg+W4hi0InmXHxtD/1favB4WdwyFxs1eOy/DvMw6+2IZBmATgGOlqhahsypk4kChhxjAFJAZ2F+JBg==",
       "dev": true,
       "requires": {
         "@commitlint/top-level": "^17.4.0",
@@ -21975,13 +21975,13 @@
       }
     },
     "@commitlint/rules": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.4.0.tgz",
-      "integrity": "sha512-lz3i1jet2NNjTWpAMwjjQjMZCPWBIHK1Kkja9o09UmUtMjRdALTb8uMLe8gCyeq3DiiZ5lLYOhbsoPK56xGQKA==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.4.2.tgz",
+      "integrity": "sha512-OGrPsMb9Fx3/bZ64/EzJehY9YDSGWzp81Pj+zJiY+r/NSgJI3nUYdlS37jykNIugzazdEXfMtQ10kmA+Kx2pZQ==",
       "dev": true,
       "requires": {
         "@commitlint/ensure": "^17.4.0",
-        "@commitlint/message": "^17.4.0",
+        "@commitlint/message": "^17.4.2",
         "@commitlint/to-lines": "^17.4.0",
         "@commitlint/types": "^17.4.0",
         "execa": "^5.0.0"
@@ -36549,9 +36549,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.8.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+          "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
           "dev": true
         },
         "diff": {

--- a/package.json
+++ b/package.json
@@ -106,8 +106,8 @@
     "year": "^0.2.1"
   },
   "devDependencies": {
-    "@commitlint/cli": "^17.4.1",
-    "@commitlint/config-conventional": "^17.4.0",
+    "@commitlint/cli": "^17.4.2",
+    "@commitlint/config-conventional": "^17.4.2",
     "auto-changelog": "^2.4.0",
     "engine-handlebars": "^1.1.0",
     "fs-exists-sync": "^0.1.0",


### PR DESCRIPTION
updating the @commitlint/cli and @commitlint/config-conventional to latest.

# Overview

## Why is this change required

- [ ] Feature
- [ ] Bug
- [ ] Test coverage
- [ ] Documentation
- [x] Other

## What changed

chore: upgrading @commitlint to latest version

## How to test it

How these changes can be tested: Yes